### PR TITLE
Add sphinx packages to dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ dependencies        =   [
                             "scikit-learn", 
                             "scipy",
                             "tqdm",
+                            "sphinx",
+                            "sphinx_rtd_theme",
+                            "sphinx_gallery",
+                            "sphinx_autodoc_typehints",
                         ]  
 
 [tool.maturin]


### PR DESCRIPTION
This is to fix an error in readthedocs online documentation builder.