### PR TITLE
update publish_to_pypi.yml for universal MacOS wheels

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -117,10 +117,12 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-12
-            target: x86_64
           - runner: macos-14
-            target: aarch64
+            target: universal2      
+          # - runner: macos-12
+          #   target: x86_64
+          # - runner: macos-14
+          #   target: aarch64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Update publish_to_pypi.yml, switching mac OS configuration to macos-14 / universal2, in order to sidestep lack of availability of macos-12 on Github servers, and to get better flexibility/compatibility.